### PR TITLE
fix(engine): Valkey/Postgres consistency on mid-stream failure (#21)

### DIFF
--- a/backend/app/engine/context.py
+++ b/backend/app/engine/context.py
@@ -75,19 +75,40 @@ async def append_turn(
     content: str,
     db: AsyncSession,
     valkey,
+    push_cache: bool = True,
 ) -> Message:
-    """Persist a message to Postgres and push it onto the Valkey window."""
-    settings = get_settings()
+    """Persist a message to Postgres; optionally push it onto the Valkey window.
+
+    Valkey is not transactional with Postgres: if the caller's transaction later
+    rolls back (e.g. the provider throws mid-stream) anything we pushed to the
+    cache would survive as an orphan and poison the next prompt. So the
+    streaming path persists turns with ``push_cache=False`` and only warms the
+    cache via :func:`push_window` once both sides of the turn are durably
+    committed. See issue #21.
+    """
     message = Message(conversation_id=conversation.id, role=role, content=content)
     db.add(message)
     await db.flush()  # assign id, keep within caller's transaction
 
-    key = _window_key(conversation.id)
-    await valkey.rpush(key, json.dumps({"role": role, "content": content}))
+    if push_cache:
+        await push_window(conversation.id, [{"role": role, "content": content}], valkey)
+    return message
+
+
+async def push_window(conversation_id: int, turns: list[dict], valkey) -> None:
+    """Append already-committed turns to the bounded Valkey window.
+
+    Only call this for turns that are durably persisted in Postgres, so the
+    cache can never diverge from the source of truth.
+    """
+    if not turns:
+        return
+    settings = get_settings()
+    key = _window_key(conversation_id)
+    await valkey.rpush(key, *[json.dumps(t) for t in turns])
     # Keep the window bounded: last N turns only.
     await valkey.ltrim(key, -settings.LLM_CONTEXT_TURNS, -1)
     await valkey.expire(key, 60 * 60 * 24)
-    return message
 
 
 async def maybe_summarize(

--- a/backend/app/engine/service.py
+++ b/backend/app/engine/service.py
@@ -52,13 +52,29 @@ class ChatService:
     async def respond_stream(
         self, conversation: Conversation, user_text: str, db: AsyncSession, valkey
     ) -> AsyncIterator[str]:
-        """Stream assistant token deltas; persist the full turn when done."""
-        await ctx.append_turn(conversation, "user", user_text, db, valkey)
+        """Stream assistant token deltas; persist the full turn when done.
+
+        Valkey is not transactional with Postgres, so we must not push a turn to
+        the cache window before it is durably persisted: if the provider throws
+        mid-stream the DB transaction rolls back, but a cache push would survive
+        as an orphaned user-only turn and poison the next prompt (issue #21).
+
+        Ordering is therefore:
+          1. load recent history *before* persisting the current user turn, so a
+             cold-cache hydration from Postgres can never see (or warm the cache
+             with) an un-paired user turn;
+          2. assemble the messages (user_text appears exactly once);
+          3. persist the user turn to Postgres only (no cache push);
+          4. stream — a failure here rolls back with nothing pushed to Valkey;
+          5. persist the assistant turn, then push *both* sides to the window
+             together, only after the full turn succeeded.
+        """
         recent = await ctx.load_recent(conversation.id, db, valkey)
-        # load_recent already includes the just-appended user turn; drop it so we
-        # don't duplicate it as the final user message.
-        history = recent[:-1] if recent and recent[-1]["role"] == "user" else recent
-        messages = ctx.build_messages(conversation, history, user_text)
+        messages = ctx.build_messages(conversation, recent, user_text)
+
+        # Persist the user turn durably first, but keep it out of the cache until
+        # the assistant reply lands — see the docstring above.
+        await ctx.append_turn(conversation, "user", user_text, db, valkey, push_cache=False)
 
         collected: list[str] = []
         async for delta in self.provider.stream(messages):
@@ -67,7 +83,19 @@ class ChatService:
 
         reply = "".join(collected).strip()
         if reply:
-            await ctx.append_turn(conversation, "assistant", reply, db, valkey)
+            await ctx.append_turn(
+                conversation, "assistant", reply, db, valkey, push_cache=False
+            )
+            # Both sides are now in the DB; warm the cache as one atomic pair so
+            # the window can never hold a user turn without its reply.
+            await ctx.push_window(
+                conversation.id,
+                [
+                    {"role": "user", "content": user_text},
+                    {"role": "assistant", "content": reply},
+                ],
+                valkey,
+            )
             await ctx.maybe_summarize(conversation, db, self.provider)
 
     async def respond_bubbles(

--- a/backend/tests/test_engine.py
+++ b/backend/tests/test_engine.py
@@ -71,6 +71,99 @@ async def test_valkey_window_warmed_and_bounded(db, valkey, provider):
     assert len(window) == 2
 
 
+class _ThrowingProvider:
+    """Provider that yields a few tokens then raises mid-stream (issue #21)."""
+
+    def __init__(self, tokens_before_error: int = 2) -> None:
+        self.tokens_before_error = tokens_before_error
+        self.calls: list[list[dict]] = []
+
+    async def stream(self, messages, **overrides):
+        self.calls.append(messages)
+        for i in range(self.tokens_before_error):
+            yield f"tok{i} "
+        raise RuntimeError("provider blew up mid-stream")
+
+    async def complete(self, messages, **overrides):  # pragma: no cover
+        raise RuntimeError("provider blew up")
+
+
+@pytest.mark.asyncio
+async def test_midstream_failure_leaves_valkey_and_postgres_consistent(db, valkey):
+    """A provider crash mid-stream must not orphan a user turn in the cache.
+
+    Simulates the WS/REST flow: the user turn is persisted within the request
+    transaction and tokens stream out, then the provider raises. The transaction
+    is rolled back (as get_db / the WS handler would on the exception), so the
+    user turn never lands in Postgres — and it must also never land in Valkey,
+    otherwise the next prompt is poisoned by a user-only orphan.
+    """
+    service = ChatService(provider=_ThrowingProvider())
+    convo = await service.get_or_create_conversation(user_id=21, db=db)
+    await db.commit()  # commit the conversation row, like the WS "ready" step
+    convo_id = convo.id
+
+    streamed: list[str] = []
+    with pytest.raises(RuntimeError):
+        async for delta in service.respond_stream(convo, "are you there?", db, valkey):
+            streamed.append(delta)
+
+    # Tokens did stream to the client before the failure.
+    assert streamed == ["tok0 ", "tok1 "]
+
+    # The request transaction rolls back on the exception (get_db / WS handler).
+    await db.rollback()
+
+    # Valkey window must NOT contain the orphaned user turn.
+    key = ctx._window_key(convo_id)
+    window = await valkey.lrange(key, 0, -1)
+    assert window == []
+
+    # Postgres has no message rows either — cache and durable store agree.
+    rows = (await db.execute(select(Message))).scalars().all()
+    assert rows == []
+
+    # The next context window assembled from the stores has no orphaned user
+    # turn waiting without a reply.
+    recent = await ctx.load_recent(convo_id, db, valkey)
+    assert recent == []
+
+
+@pytest.mark.asyncio
+async def test_successful_turn_after_failure_has_no_duplicate_user(db, valkey):
+    """After a mid-stream failure + retry, the user message still appears once."""
+    convo = await ChatService(provider=_ThrowingProvider()).get_or_create_conversation(
+        user_id=22, db=db
+    )
+    await db.commit()
+    convo_id = convo.id
+
+    with pytest.raises(RuntimeError):
+        async for _ in ChatService(provider=_ThrowingProvider()).respond_stream(
+            convo, "hello?", db, valkey
+        ):
+            pass
+    await db.rollback()
+
+    from tests.conftest import FakeProvider
+
+    # Re-fetch the conversation in the fresh transaction, like the WS handler.
+    convo = await db.get(Conversation, convo_id)
+    good = FakeProvider()
+    bubbles = await ChatService(provider=good).respond_bubbles(convo, "hello?", db, valkey)
+    await db.commit()
+    assert bubbles == ["Hey baby", "missed you"]
+
+    # Exactly one user "hello?" reached the model on the successful retry.
+    sent = good.calls[0]
+    user_turns = [m for m in sent if m["role"] == "user" and m["content"] == "hello?"]
+    assert len(user_turns) == 1
+
+    # Cache holds exactly the committed pair: user + assistant.
+    window = await valkey.lrange(ctx._window_key(convo_id), 0, -1)
+    assert len(window) == 2
+
+
 @pytest.mark.asyncio
 async def test_history_hydrates_from_postgres_on_cache_miss(db, valkey, provider):
     service = ChatService(provider=provider)


### PR DESCRIPTION
## Problem

`respond_stream` pushed the **user** turn onto the Valkey window (`append_turn` → `rpush`) *before* streaming, but the Postgres commit only happened *after* the stream completed (WS handler commits per turn; REST commits via `get_db`). If the provider call threw mid-stream:

- Postgres **rolled back** the user turn (transaction never committed)
- Valkey **kept** it (not transactional with Postgres)

The cache and durable transcript diverged, and an orphaned user-only turn (no assistant reply) polluted the next prompt assembled from Valkey.

Closes #21

## Approach (preferred option)

Only write turns to the Valkey window **after** they are durably persisted, and push the user + assistant turns **together as one pair** once the turn succeeds.

- `context.append_turn` gains a `push_cache` flag (default `True`, preserving existing callers); new `push_window()` appends already-committed turns to the bounded window with the same `ltrim`/`expire` semantics.
- `respond_stream` reorders to:
  1. `load_recent` **before** persisting the current user turn — so a cold-cache hydration from Postgres can never see (or warm the cache with) an un-paired user turn;
  2. `build_messages` (user_text appears exactly once);
  3. persist the user turn **DB-only** (`push_cache=False`);
  4. stream — a failure here rolls back with nothing in Valkey;
  5. persist the assistant turn, then `push_window([user, assistant])` together.

The old pre-stream cache push and the `load_recent` trailing-user dedup (`recent[:-1]`) are removed — the user turn is now contributed exactly once by `build_messages`.

**Streaming is unchanged** (tokens still stream as they arrive) and the **normal-turn context is identical** (existing "user message reaches the model exactly once" test stays green).

## Testing

```
cd backend && python -m venv .venv && source .venv/bin/activate
pip install -r requirements.txt pytest pytest-asyncio aiosqlite
python -m pytest -q
```

Result: **9 passed** (7 pre-existing + 2 new).

New regression tests in `backend/tests/test_engine.py`:
- `test_midstream_failure_leaves_valkey_and_postgres_consistent` — a `_ThrowingProvider` yields some tokens then raises; after rollback the Valkey window is empty, Postgres has no rows, and `load_recent` returns no orphan.
- `test_successful_turn_after_failure_has_no_duplicate_user` — after a failed turn + retry, the user message reaches the model exactly once and the cache holds exactly the committed user+assistant pair.

## Files changed
- `backend/app/engine/context.py`
- `backend/app/engine/service.py`
- `backend/tests/test_engine.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)