### PR TITLE
fix(engine): gap-free bounded conversation summary (#19, #20)

### DIFF
--- a/backend/app/engine/context.py
+++ b/backend/app/engine/context.py
@@ -114,12 +114,28 @@ async def push_window(conversation_id: int, turns: list[dict], valkey) -> None:
 async def maybe_summarize(
     conversation: Conversation, db: AsyncSession, provider: LLMProvider
 ) -> None:
-    """Fold older turns into ``conversation.summary`` once history grows long.
+    """Incrementally fold turns that have aged out of the recent window into
+    ``conversation.summary``, keeping summary + window gap-free and the
+    summarizer input bounded.
 
-    Runs periodically (every context-window's worth of new messages past the
-    threshold) so we summarize occasionally, not on every turn.
+    Invariant maintained: messages with ``id <= conversation.summarized_through``
+    are represented in ``summary``; messages with a greater id are in the recent
+    window (the last ``LLM_CONTEXT_TURNS``). The boundary is advanced so the two
+    together tile the entire history with no gap (#19).
+
+    Only the messages that *newly* aged out since the last run are read and
+    folded in, alongside the previous summary text — the full prefix is never
+    re-read, so the summarizer input stays bounded by ~LLM_CONTEXT_TURNS
+    regardless of total conversation length (#20).
     """
     settings = get_settings()
+    keep = settings.LLM_CONTEXT_TURNS
+
+    max_id = await db.scalar(
+        select(func.max(Message.id)).where(
+            Message.conversation_id == conversation.id
+        )
+    )
     total = await db.scalar(
         select(func.count(Message.id)).where(
             Message.conversation_id == conversation.id
@@ -127,33 +143,63 @@ async def maybe_summarize(
     )
     if not total or total < settings.LLM_SUMMARY_THRESHOLD:
         return
-    if total % settings.LLM_CONTEXT_TURNS != 0:
+
+    # The recent window is the last ``keep`` messages by id. Everything older than
+    # the window's first message must be covered by the summary. Find the id of
+    # the oldest message still inside the window so the summary boundary can be
+    # advanced to exactly meet it (no gap, no overlap).
+    window_first_id = await db.scalar(
+        select(func.min(Message.id)).where(
+            Message.conversation_id == conversation.id,
+            Message.id.in_(
+                select(Message.id)
+                .where(Message.conversation_id == conversation.id)
+                .order_by(Message.id.desc())
+                .limit(keep)
+            ),
+        )
+    )
+    if window_first_id is None:
         return
 
-    # Summarize everything except the most recent window.
-    keep = settings.LLM_CONTEXT_TURNS
+    # Target boundary: everything strictly below the window must be summarized.
+    target_through = window_first_id - 1
+    if target_through <= conversation.summarized_through:
+        return  # nothing new has aged out of the window yet
+
+    # Read ONLY the newly-aged-out messages (bounded by ~keep per run).
     result = await db.execute(
         select(Message)
-        .where(Message.conversation_id == conversation.id)
+        .where(
+            Message.conversation_id == conversation.id,
+            Message.id > conversation.summarized_through,
+            Message.id <= target_through,
+        )
         .order_by(Message.id.asc())
-        .limit(max(total - keep, 0))
     )
-    older = result.scalars().all()
-    if not older:
+    newly_aged = result.scalars().all()
+    if not newly_aged:
         return
 
-    transcript = "\n".join(f"{m.role}: {m.content}" for m in older)
+    transcript = "\n".join(f"{m.role}: {m.content}" for m in newly_aged)
+    prior = conversation.summary or ""
+    user_content = (
+        (f"# Existing memory note (carry forward, do not drop facts)\n{prior}\n\n" if prior else "")
+        + "# New turns to fold into the memory note\n"
+        + transcript
+    )
     prompt = [
         {
             "role": "system",
             "content": (
-                "Summarize the following adult roleplay conversation into a concise "
-                "memory note (3-6 sentences). Capture names introduced, ongoing "
-                "scenarios, established dynamics, and key facts the characters should "
-                "remember. Write it as factual notes, not narrative."
+                "You maintain a running memory note for an adult roleplay "
+                "conversation. Merge the new turns into the existing memory note "
+                "and return a single concise note (3-6 sentences). Preserve names "
+                "introduced, ongoing scenarios, established dynamics, and key facts "
+                "the characters should remember. Write factual notes, not narrative."
             ),
         },
-        {"role": "user", "content": transcript},
+        {"role": "user", "content": user_content},
     ]
     try:
         summary = await provider.complete(prompt, max_tokens=300, temperature=0.3)
@@ -161,4 +207,5 @@ async def maybe_summarize(
         return  # summarization is best-effort; never block the chat
     if summary.strip():
         conversation.summary = summary.strip()
+        conversation.summarized_through = target_through
         db.add(conversation)

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -20,6 +20,12 @@ class Conversation(Base):
     persona: Mapped[str] = mapped_column(String(32), nullable=False, default="sophia")
     # Rolling summary of older turns, prepended to context once history grows long.
     summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Highest Message.id already folded into ``summary``. Everything with
+    # id <= summarized_through lives in the summary; everything with a greater id
+    # lives in the recent window. Together they tile the full history with no gap.
+    summarized_through: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     last_message_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow

--- a/backend/tests/test_engine.py
+++ b/backend/tests/test_engine.py
@@ -3,6 +3,7 @@
 import pytest
 from sqlalchemy import select
 
+from app.core.config import get_settings
 from app.engine import context as ctx
 from app.engine.personas import build_system_prompt, get_persona
 from app.engine.service import ChatService, split_bubbles
@@ -176,3 +177,95 @@ async def test_history_hydrates_from_postgres_on_cache_miss(db, valkey, provider
 
     recent = await ctx.load_recent(convo.id, db, valkey)  # empty cache → DB
     assert [m["content"] for m in recent] == ["older", "reply"]
+
+
+async def _seed_messages(convo: Conversation, n: int, db) -> list[Message]:
+    """Insert ``n`` alternating user/assistant messages and return them by id."""
+    msgs = []
+    for i in range(n):
+        role = "user" if i % 2 == 0 else "assistant"
+        msgs.append(Message(conversation_id=convo.id, role=role, content=f"msg-{i}"))
+    db.add_all(msgs)
+    await db.flush()
+    return msgs
+
+
+@pytest.mark.asyncio
+async def test_summary_and_window_are_gap_free(db, valkey, provider):
+    """#19 regression: every message is covered by either the summary
+    (id <= summarized_through) or the recent window (last N) — never absent
+    from both. Checked across many total lengths as the window slides."""
+    keep = get_settings().LLM_CONTEXT_TURNS
+    service = ChatService(provider=provider)
+
+    for k in range(1, keep + 1):
+        total = keep * 2 + k  # past the summary threshold, window has slid
+        convo = await service.get_or_create_conversation(user_id=1000 + k, db=db)
+        msgs = await _seed_messages(convo, total, db)
+
+        await ctx.maybe_summarize(convo, db, provider)
+
+        all_ids = {m.id for m in msgs}
+        # Recent window = last `keep` messages by id (what build_messages will use).
+        window_ids = {m.id for m in sorted(msgs, key=lambda m: m.id)[-keep:]}
+        summarized_ids = {m.id for m in msgs if m.id <= convo.summarized_through}
+
+        covered = window_ids | summarized_ids
+        missing = all_ids - covered
+        assert not missing, (
+            f"total={total}: ids {sorted(missing)} are in NEITHER summary "
+            f"(through {convo.summarized_through}) nor window {sorted(window_ids)}"
+        )
+        # Boundary must meet the window exactly: summary ends right where the
+        # window begins (no gap, no large overlap).
+        assert convo.summarized_through == min(window_ids) - 1
+
+
+@pytest.mark.asyncio
+async def test_summarizer_input_is_bounded(db, valkey, provider):
+    """#20 regression: the transcript handed to the summarizer per call stays
+    bounded (~CONTEXT_TURNS messages) and does NOT grow with total history,
+    because only newly-aged-out turns are folded in each run."""
+    settings = get_settings()
+    keep = settings.LLM_CONTEXT_TURNS
+    threshold = settings.LLM_SUMMARY_THRESHOLD
+    service = ChatService(provider=provider)
+    convo = await service.get_or_create_conversation(user_id=2000, db=db)
+
+    # Seed past the threshold so summarization is active, then walk the
+    # conversation forward many turns, summarizing each step like the live path.
+    await _seed_messages(convo, threshold, db)
+
+    def _turns_in_last_call() -> int:
+        user_msg = provider.calls[-1][-1]["content"]
+        return sum(
+            1
+            for ln in user_msg.splitlines()
+            if ln.startswith("user:") or ln.startswith("assistant:")
+        )
+
+    # First (catch-up) summarization, then keep growing the conversation far
+    # beyond `keep` and summarize at each step like the live path.
+    await ctx.maybe_summarize(convo, db, provider)
+    first_call_turns = _turns_in_last_call()
+
+    per_step_turns: list[int] = []
+    for _ in range(keep * 4):  # grow total by 4*keep — well past any window
+        await _seed_messages(convo, 1, db)
+        before = len(provider.calls)
+        await ctx.maybe_summarize(convo, db, provider)
+        if len(provider.calls) > before:
+            per_step_turns.append(_turns_in_last_call())
+
+    max_turns = max([first_call_turns, *per_step_turns])
+
+    # Bounded independent of total length: even the one-time catch-up fold is
+    # capped by the (constant) threshold-sized prefix, and steady-state folds are
+    # tiny. Unbounded behaviour would feed total-keep lines (hundreds+).
+    assert 0 < max_turns <= threshold, (
+        f"summarizer ingested {max_turns} turns; expected <= {threshold}"
+    )
+    # And it must NOT grow as the conversation lengthens: steady-state folds stay
+    # small no matter how long the chat gets.
+    assert per_step_turns, "expected steady-state summarizations to occur"
+    assert max(per_step_turns) <= keep


### PR DESCRIPTION
## Summary

Redesigns conversation memory so the rolling **summary** and the **recent window** always tile the full history with **no gap**, while keeping the summarizer **input bounded** regardless of total conversation length. Fixes two related bugs together.

### #19 — Context silently dropped turns between summary updates
The summary only refreshed when `total % LLM_CONTEXT_TURNS == 0`, but the recent window (`load_recent`, last N) slides every turn. Between summary updates, turns older than the window but newer than the last-summarized prefix fell out of **both** and vanished from context (e.g. at total=50 the summary still covered only msgs 1–20 while the window covered 31–50, so 21–30 were in neither).

### #20 — Rolling summary recomputed over an unbounded prefix
`maybe_summarize` re-read **all** `total - keep` messages from message 1 every run, so the summarizer transcript grew without bound — rising cost and eventual context overflow. "Rolling" in name only.

## Design (one coherent fix)

- Add `Conversation.summarized_through` (int, default 0): the highest `Message.id` already folded into `summary`.
  - **Invariant:** `id <= summarized_through` lives in the summary; a greater id lives in the recent window. Together they tile the whole history.
- `maybe_summarize` advances the boundary to **exactly meet the window's first message** (`summarized_through = window_first_id - 1`) every turn once past the threshold → **no turn is ever absent from both** (#19).
- It folds **only the newly-aged-out turns** into the existing summary text (carrying the prior note forward), never re-reading the full prefix → summarizer input stays **bounded** by the threshold/window size no matter how long the chat is (#20).
- Summarization remains **best-effort**: provider failures never block or fail the chat.
- `build_messages` is unchanged — the gap-free guarantee now comes from the boundary alignment maintained in `maybe_summarize`.

## DB column / migration note

Added column `conversations.summarized_through` (NOT NULL, `server_default="0"`). Tables in tests/dev are created via `Base.metadata.create_all`, so no migration is needed there. **Deferred follow-up:** an Alembic migration is required to add this column to existing Postgres deployments (out of scope per the task).

## Testing

```
cd backend && python -m pytest -q
9 passed
```

- All 7 pre-existing tests still pass.
- `test_summary_and_window_are_gap_free` — drives conversations to `CONTEXT_TURNS*2 + k` for every `k` in 1..CONTEXT_TURNS and asserts every message id is covered by the summary or the window, and the boundary meets the window exactly (#19 regression).
- `test_summarizer_input_is_bounded` — grows a conversation by `4*CONTEXT_TURNS` turns and asserts, via `FakeProvider` call recording, that no summarizer call ever ingests more than the threshold-sized prefix and steady-state folds stay `<= CONTEXT_TURNS` (i.e. input does not grow with total length) (#20 regression).

Note: `aiosqlite` is required to run the async tests but is not in `requirements.txt` (test-only dep); installed in the local venv to run the suite.

Closes #19
Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)