### PR TITLE
fix(infra): reconcile deploy secrets with app config (OpenRouter, Stripe)

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -111,7 +111,7 @@ jobs:
         TF_VAR_stripe_webhook_secret: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
         TF_VAR_jwt_secret_key: ${{ secrets.JWT_SECRET_KEY }}
         TF_VAR_telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-        TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+        TF_VAR_openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
         TF_VAR_encryption_key: ${{ secrets.ENCRYPTION_KEY }}
         TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}
         TF_VAR_slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
@@ -163,7 +163,7 @@ jobs:
         TF_VAR_stripe_webhook_secret: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
         TF_VAR_jwt_secret_key: ${{ secrets.JWT_SECRET_KEY }}
         TF_VAR_telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-        TF_VAR_openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+        TF_VAR_openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
         TF_VAR_encryption_key: ${{ secrets.ENCRYPTION_KEY }}
         TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}
         TF_VAR_slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -72,7 +72,7 @@ max_scale_instances = 2 # Limit scaling for dev
 # - stripe_secret_key (test keys)
 # - jwt_secret_key (test secret)
 # - telegram_bot_token (test bot - optional)
-# - openai_api_key (optional)
+# - openrouter_api_key (conversation engine)
 # - encryption_key (test key)
 # - alert_email (developer email)
 # - slack_webhook (optional)

--- a/terraform/environments/production/terraform.tfvars
+++ b/terraform/environments/production/terraform.tfvars
@@ -76,7 +76,7 @@ max_scale_instances = 5
 # - stripe_secret_key
 # - jwt_secret_key
 # - telegram_bot_token (optional)
-# - openai_api_key (optional)
+# - openrouter_api_key (conversation engine)
 # - encryption_key
 # - alert_email
 # - slack_webhook (optional)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -146,7 +146,7 @@ module "app_platform" {
   stripe_secret_key  = var.stripe_secret_key
   telegram_bot_token = var.telegram_bot_token
   jwt_secret_key     = var.jwt_secret_key
-  openai_api_key     = var.openai_api_key
+  openrouter_api_key = var.openrouter_api_key
   encryption_key     = var.encryption_key
 
   depends_on = [

--- a/terraform/modules/app-platform/variables.tf
+++ b/terraform/modules/app-platform/variables.tf
@@ -169,8 +169,8 @@ variable "telegram_bot_token" {
   default     = ""
 }
 
-variable "openai_api_key" {
-  description = "OpenAI API key (optional)"
+variable "openrouter_api_key" {
+  description = "OpenRouter API key for the conversation engine"
   type        = string
   sensitive   = true
   default     = ""

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -56,9 +56,10 @@ variable "do_spaces_secret_key" {
 #==============================================================================
 
 variable "stripe_secret_key" {
-  description = "Stripe secret key for payment processing"
+  description = "Stripe secret key for payment processing (Phase 4 — optional until then)"
   type        = string
   sensitive   = true
+  default     = ""
 }
 
 variable "stripe_webhook_secret" {
@@ -81,8 +82,8 @@ variable "jwt_secret_key" {
   sensitive   = true
 }
 
-variable "openai_api_key" {
-  description = "OpenAI API key (if using external LLM)"
+variable "openrouter_api_key" {
+  description = "OpenRouter API key for the conversation engine"
   type        = string
   sensitive   = true
   default     = ""


### PR DESCRIPTION
Closes #28.

The deploy config still injected `openai_api_key` (the app uses **OpenRouter**) and required Stripe (which is **Phase 4**). This aligns terraform + the deploy workflow with the app's actual env.

## Changes
- **Rename** terraform var `openai_api_key` → `openrouter_api_key` (root `variables.tf` + `modules/app-platform/variables.tf`), and the pass-through in `main.tf`.
- **Workflow** (`terraform-deploy.yml`, both plan + apply jobs): `TF_VAR_openai_api_key: secrets.OPENAI_API_KEY` → `TF_VAR_openrouter_api_key: secrets.OPENROUTER_API_KEY`.
- **`stripe_secret_key`** now defaults to `""` so deploys don't require it until Phase 4 (matches `stripe_webhook_secret`).
- Updated env tfvars comments.

`terraform fmt` clean.

## ⚠️ Required before this actually deploys the app
- [ ] Add a GitHub Actions secret **`OPENROUTER_API_KEY`** (and **rotate** the key that was shared in chat first).
- [ ] App Platform is still a placeholder (`ignore_changes=[spec]`); when the real app spec lands, wire each secret env as `type = "SECRET"` (encrypted), not plaintext.

## Note
`environments/*/terraform.tfvars` only carry comments here; real values live in `.auto.tfvars` (gitignored) / GitHub secrets. The local `.auto.tfvars` was updated for correctness but is **not** committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)