### PR TITLE
feat(deploy): real App Platform spec + managed-DB connection handling

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -112,6 +112,8 @@ jobs:
         TF_VAR_jwt_secret_key: ${{ secrets.JWT_SECRET_KEY }}
         TF_VAR_telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         TF_VAR_openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+        TF_VAR_magic_link_secret: ${{ secrets.MAGIC_LINK_SECRET }}
+        TF_VAR_resend_api_key: ${{ secrets.RESEND_API_KEY }}
         TF_VAR_encryption_key: ${{ secrets.ENCRYPTION_KEY }}
         TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}
         TF_VAR_slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
@@ -164,6 +166,8 @@ jobs:
         TF_VAR_jwt_secret_key: ${{ secrets.JWT_SECRET_KEY }}
         TF_VAR_telegram_bot_token: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         TF_VAR_openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+        TF_VAR_magic_link_secret: ${{ secrets.MAGIC_LINK_SECRET }}
+        TF_VAR_resend_api_key: ${{ secrets.RESEND_API_KEY }}
         TF_VAR_encryption_key: ${{ secrets.ENCRYPTION_KEY }}
         TF_VAR_alert_email: ${{ secrets.ALERT_EMAIL }}
         TF_VAR_slack_webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,9 +15,15 @@ class Settings(BaseSettings):
 
     # Database
     DATABASE_URL: str
+    # CA cert (PEM) for verifying managed-Postgres TLS (DigitalOcean's CA is not
+    # a public root). Leave empty for local/plaintext dev.
+    DATABASE_SSL_CA: str = ""
 
     # Valkey (Redis-compatible)
     VALKEY_URL: str
+    # CA cert (PEM) for verifying managed-Valkey TLS. Empty = verify against
+    # system roots (or no TLS for local dev).
+    VALKEY_SSL_CA: str = ""
 
     # JWT Configuration
     JWT_SECRET: str

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -1,11 +1,64 @@
 """Database connection and session management using SQLAlchemy async."""
 
+import base64
+import ssl
 from typing import AsyncGenerator
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
 
 from app.core.config import get_settings
+
+# libpq-only query params that asyncpg rejects (SSL is applied via connect_args).
+_LIBPQ_ONLY_PARAMS = {"sslmode", "ssl", "channel_binding", "sslrootcert", "sslcert", "sslkey"}
+
+
+def ca_pem(ca: str) -> str:
+    """Return PEM text from a CA cert that may be raw PEM or base64-encoded PEM.
+
+    DigitalOcean's ``digitalocean_database_ca`` exposes the cert base64-encoded;
+    accept either form so the env wiring is robust.
+    """
+    ca = ca.strip()
+    if "BEGIN CERTIFICATE" in ca:
+        return ca
+    try:
+        return base64.b64decode(ca).decode()
+    except Exception:
+        return ca
+
+
+def normalize_db_url(url: str) -> str:
+    """Coerce a Postgres URL to the asyncpg driver and drop libpq-only params.
+
+    Managed providers (e.g. DigitalOcean) hand out ``postgresql://…?sslmode=require``;
+    SQLAlchemy needs ``postgresql+asyncpg://…`` and asyncpg errors on ``sslmode``.
+    SSL itself is reattached via :func:`db_connect_args`.
+    """
+    parts = urlsplit(url)
+    scheme = parts.scheme
+    if scheme in ("postgres", "postgresql") or scheme.startswith("postgresql+"):
+        scheme = "postgresql+asyncpg"
+    query = [(k, v) for k, v in parse_qsl(parts.query) if k not in _LIBPQ_ONLY_PARAMS]
+    return urlunsplit((scheme, parts.netloc, parts.path, urlencode(query), parts.fragment))
+
+
+def db_connect_args(url: str, ca_cert: str = "") -> dict:
+    """asyncpg connect args: encrypt and **verify** the server certificate.
+
+    Managed providers whose CA is not a public root (DigitalOcean) require the
+    cluster CA PEM, supplied via ``settings.DATABASE_SSL_CA``, so verification
+    succeeds without disabling it. Returns no SSL when the URL opts out
+    (``sslmode=disable`` or no sslmode for local/plaintext dev).
+    """
+    sslmode = dict(parse_qsl(urlsplit(url).query)).get("sslmode", "")
+    if sslmode in ("", "disable"):
+        return {}
+    ctx = ssl.create_default_context()  # CERT_REQUIRED + hostname check
+    if ca_cert:
+        ctx.load_verify_locations(cadata=ca_pem(ca_cert))
+    return {"ssl": ctx}
 
 
 class Base(DeclarativeBase):
@@ -18,11 +71,12 @@ settings = get_settings()
 
 # Create async engine
 engine = create_async_engine(
-    settings.DATABASE_URL,
+    normalize_db_url(settings.DATABASE_URL),
     echo=settings.DEBUG,
     pool_pre_ping=True,
     pool_size=5,
     max_overflow=10,
+    connect_args=db_connect_args(settings.DATABASE_URL, settings.DATABASE_SSL_CA),
 )
 
 # Create async session factory

--- a/backend/app/core/valkey.py
+++ b/backend/app/core/valkey.py
@@ -14,8 +14,8 @@ def create_valkey_client() -> Valkey:
     settings = get_settings()
     parsed = urlparse(settings.VALKEY_URL)
 
-    # DigitalOcean managed Valkey uses SSL (valkeys:// protocol)
-    use_ssl = parsed.scheme == "valkeys"
+    # DigitalOcean managed Valkey uses TLS — emitted as either valkeys:// or rediss://
+    use_ssl = parsed.scheme in ("valkeys", "rediss")
 
     # Extract connection parameters
     host = parsed.hostname or "localhost"
@@ -24,10 +24,15 @@ def create_valkey_client() -> Valkey:
     username = parsed.username or "default"
 
     if use_ssl:
-        # Create SSL context for DigitalOcean managed Valkey
+        # Verify the server cert; load the managed cluster CA when provided
+        # (DigitalOcean's CA is not a public root).
         ssl_context = ssl.create_default_context()
         ssl_context.check_hostname = True
         ssl_context.verify_mode = ssl.CERT_REQUIRED
+        if settings.VALKEY_SSL_CA:
+            from app.core.database import ca_pem
+
+            ssl_context.load_verify_locations(cadata=ca_pem(settings.VALKEY_SSL_CA))
 
         return Valkey(
             host=host,

--- a/backend/scripts/seed_test_user.py
+++ b/backend/scripts/seed_test_user.py
@@ -1,0 +1,64 @@
+"""Seed an age-verified test user and print a JWT — for post-deploy smoke tests.
+
+Bypasses the Resend email/magic-link flow so the chat can be exercised before
+the public auth path (Resend + domain) is wired.
+
+Run from `backend/` with the TARGET database's env set. The managed DB is on a
+private VPC, so run this from inside the VPC (App Platform console/exec) or add
+your IP to `allowed_admin_ips` and use the cluster's public connection URI.
+
+    DATABASE_URL='postgresql://…?sslmode=require' \
+    DATABASE_SSL_CA="$(doctl databases certificate get <pg-id> --format Certificate --no-header)" \
+    JWT_SECRET='<the deployed JWT secret>' \
+    VALKEY_URL='rediss://…' MAGIC_LINK_SECRET=x RESEND_API_KEY=x \
+    python -m scripts.seed_test_user
+
+Prints the user id and a 12-hour access token. Use it as a Bearer token against
+`POST /api/chat/message` or inject into the web app's localStorage as
+`access_token`.
+"""
+
+import asyncio
+import os
+from datetime import datetime, timedelta, timezone
+
+import jwt
+from sqlalchemy import select
+
+from app.core.config import get_settings
+from app.core.database import AsyncSessionLocal, create_tables
+from app.models.user import User
+
+EMAIL = os.environ.get("SEED_EMAIL", "tester@intimateai.local")
+
+
+async def main() -> None:
+    await create_tables()  # no-op if the app already created the schema
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(select(User).where(User.email == EMAIL))
+        user = result.scalar_one_or_none()
+        if user is None:
+            user = User(email=EMAIL)
+            db.add(user)
+        user.email_verified = True
+        user.age_verified = True
+        user.is_active = True
+        await db.commit()
+        await db.refresh(user)
+        user_id = user.id
+
+    settings = get_settings()
+    now = datetime.now(timezone.utc)
+    token = jwt.encode(
+        {"sub": str(user_id), "exp": now + timedelta(hours=12), "type": "access"},
+        settings.JWT_SECRET,
+        algorithm="HS256",
+    )
+    print(f"user_id: {user_id}")
+    print(f"email:   {EMAIL}")
+    print(f"ACCESS_TOKEN: {token}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/tests/test_db_url.py
+++ b/backend/tests/test_db_url.py
@@ -1,0 +1,37 @@
+"""Tests for managed-DB connection-string normalization (prod deploy)."""
+
+import ssl
+
+from app.core.database import db_connect_args, normalize_db_url
+
+
+def test_normalize_adds_asyncpg_driver():
+    assert normalize_db_url("postgresql://u:p@h:5432/db").startswith(
+        "postgresql+asyncpg://"
+    )
+    # Already-asyncpg is idempotent.
+    assert normalize_db_url("postgresql+asyncpg://u:p@h/db") == (
+        "postgresql+asyncpg://u:p@h/db"
+    )
+
+
+def test_normalize_strips_libpq_only_params():
+    out = normalize_db_url("postgresql://u:p@h:5432/db?sslmode=require")
+    assert "sslmode" not in out
+    assert out.startswith("postgresql+asyncpg://")
+    # A DO-style URI with multiple libpq params keeps only asyncpg-safe ones.
+    out2 = normalize_db_url("postgres://u:p@h:25060/defaultdb?sslmode=require&connect_timeout=10")
+    assert "sslmode" not in out2 and "connect_timeout=10" in out2
+
+
+def test_connect_args_ssl_verifies():
+    args = db_connect_args("postgresql://u:p@h/db?sslmode=require")
+    ctx = args["ssl"]
+    assert isinstance(ctx, ssl.SSLContext)
+    # Verification stays ON (no MITM exposure).
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_connect_args_none_for_plaintext_or_disabled():
+    assert db_connect_args("postgresql://u:p@localhost/db") == {}
+    assert db_connect_args("postgresql://u:p@localhost/db?sslmode=disable") == {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -141,12 +141,16 @@ module "app_platform" {
   # Database connections
   postgres_connection_uri = module.database.postgres_private_uri
   redis_connection_uri    = module.database.redis_private_uri
+  postgres_ca_cert        = module.database.postgres_ca_cert
+  redis_ca_cert           = module.database.redis_ca_cert
 
   # Environment variables
   stripe_secret_key  = var.stripe_secret_key
   telegram_bot_token = var.telegram_bot_token
   jwt_secret_key     = var.jwt_secret_key
   openrouter_api_key = var.openrouter_api_key
+  magic_link_secret  = var.magic_link_secret
+  resend_api_key     = var.resend_api_key
   encryption_key     = var.encryption_key
 
   depends_on = [

--- a/terraform/modules/app-platform/main.tf
+++ b/terraform/modules/app-platform/main.tf
@@ -13,44 +13,129 @@ terraform {
 #==============================================================================
 # APP PLATFORM APPLICATION
 #==============================================================================
-# Note: The full App Platform app is deferred until frontend/backend code exists.
-# This creates a placeholder app spec that can be updated when code is ready.
-
-# App Platform application
-# The app exists and will be updated when code is deployed
-# For now it's a placeholder with deployment intentionally allowed to fail
+# Two components on one app, fronted by App Platform ingress:
+#   - api: FastAPI backend (built from backend/Dockerfile), served at /api
+#   - web: React/Vite static SPA, served at /
+# Requires a DigitalOcean <-> GitHub OAuth connection so App Platform can build
+# from the repo. Secrets are injected as SECRET-type env vars (encrypted at rest).
 resource "digitalocean_app" "chatbotai" {
   spec {
     name   = var.name_prefix
     region = var.region
 
-    # Static site placeholder - will be replaced with actual app via CI/CD
-    # Using inline HTML to avoid build failures
-    static_site {
-      name           = "placeholder"
-      build_command  = "echo 'Placeholder'"
-      output_dir     = "."
-      index_document = "index.html"
+    # ---- API: FastAPI backend ------------------------------------------------
+    service {
+      name               = "api"
+      instance_count     = var.api_instance_count
+      instance_size_slug = var.api_instance_size
+      http_port          = 8080
 
-      # Use a sample repo that always succeeds
-      git {
-        repo_clone_url = "https://github.com/digitalocean/sample-html.git"
-        branch         = "main"
+      github {
+        repo           = var.github_repo
+        branch         = var.github_branch
+        deploy_on_push = var.github_auto_deploy
+      }
+      source_dir      = "backend"
+      dockerfile_path = "backend/Dockerfile"
+
+      health_check {
+        http_path = "/health"
       }
 
-      # Environment variables
+      # Connection strings (the app normalises the driver/SSL itself).
       env {
-        key   = "NODE_ENV"
+        key   = "DATABASE_URL"
+        value = var.postgres_connection_uri
+        type  = "SECRET"
+      }
+      env {
+        key   = "DATABASE_SSL_CA"
+        value = var.postgres_ca_cert
+        type  = "SECRET"
+      }
+      env {
+        key   = "VALKEY_URL"
+        value = var.redis_connection_uri
+        type  = "SECRET"
+      }
+      env {
+        key   = "VALKEY_SSL_CA"
+        value = var.redis_ca_cert
+        type  = "SECRET"
+      }
+      env {
+        key   = "JWT_SECRET"
+        value = var.jwt_secret_key
+        type  = "SECRET"
+      }
+      env {
+        key   = "MAGIC_LINK_SECRET"
+        value = var.magic_link_secret
+        type  = "SECRET"
+      }
+      env {
+        key   = "RESEND_API_KEY"
+        value = var.resend_api_key
+        type  = "SECRET"
+      }
+      env {
+        key   = "OPENROUTER_API_KEY"
+        value = var.openrouter_api_key
+        type  = "SECRET"
+      }
+      env {
+        key   = "APP_URL"
+        value = "https://${var.domain_name}"
+      }
+      env {
+        key   = "ENVIRONMENT"
         value = var.environment
       }
+      env {
+        key   = "DEBUG"
+        value = "false"
+      }
     }
-  }
 
-  lifecycle {
-    # Ignore changes to spec as app will be updated via CI/CD
-    ignore_changes = [
-      spec
-    ]
+    # ---- WEB: React/Vite SPA (static) ---------------------------------------
+    static_site {
+      name              = "web"
+      build_command     = "npm ci && npm run build"
+      output_dir        = "dist"
+      catchall_document = "index.html" # client-side routing fallback
+
+      github {
+        repo           = var.github_repo
+        branch         = var.github_branch
+        deploy_on_push = var.github_auto_deploy
+      }
+      source_dir = "frontend"
+    }
+
+    # ---- Ingress: /api -> api (prefix stripped), everything else -> web ------
+    ingress {
+      rule {
+        component {
+          name                 = "api"
+          preserve_path_prefix = false # backend sees /auth, /chat, /health
+        }
+        match {
+          path {
+            prefix = "/api"
+          }
+        }
+      }
+      rule {
+        component {
+          name = "web"
+        }
+        match {
+          path {
+            prefix = "/"
+          }
+        }
+      }
+    }
   }
 }
 

--- a/terraform/modules/app-platform/variables.tf
+++ b/terraform/modules/app-platform/variables.tf
@@ -127,6 +127,20 @@ variable "redis_connection_uri" {
   sensitive   = true
 }
 
+variable "postgres_ca_cert" {
+  description = "CA certificate (PEM/base64) for verifying Postgres TLS"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "redis_ca_cert" {
+  description = "CA certificate (PEM/base64) for verifying Valkey/Redis TLS"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "postgres_cluster_name" {
   description = "Name of PostgreSQL cluster for App Platform reference"
   type        = string
@@ -171,6 +185,20 @@ variable "telegram_bot_token" {
 
 variable "openrouter_api_key" {
   description = "OpenRouter API key for the conversation engine"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "magic_link_secret" {
+  description = "Secret for signing passwordless magic-link tokens"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "resend_api_key" {
+  description = "Resend API key for sending magic-link emails"
   type        = string
   sensitive   = true
   default     = ""

--- a/terraform/modules/database/ca.tf
+++ b/terraform/modules/database/ca.tf
@@ -1,0 +1,22 @@
+# CA certificates for the managed clusters, passed to the app so it can verify
+# managed-DB TLS without disabling certificate checks (DO's CA isn't a public root).
+
+data "digitalocean_database_ca" "postgres" {
+  cluster_id = digitalocean_database_cluster.postgres.id
+}
+
+data "digitalocean_database_ca" "redis" {
+  cluster_id = digitalocean_database_cluster.redis.id
+}
+
+output "postgres_ca_cert" {
+  description = "CA certificate for verifying the Postgres cluster TLS"
+  value       = data.digitalocean_database_ca.postgres.certificate
+  sensitive   = true
+}
+
+output "redis_ca_cert" {
+  description = "CA certificate for verifying the Valkey/Redis cluster TLS"
+  value       = data.digitalocean_database_ca.redis.certificate
+  sensitive   = true
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -89,6 +89,20 @@ variable "openrouter_api_key" {
   default     = ""
 }
 
+variable "magic_link_secret" {
+  description = "Secret for signing passwordless magic-link tokens"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "resend_api_key" {
+  description = "Resend API key for sending magic-link emails"
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "encryption_key" {
   description = "Application encryption key for sensitive data"
   type        = string


### PR DESCRIPTION
Makes the chat actually deployable to DigitalOcean App Platform. Advances **#25/#26/#27** (deploy enablement) and the app-spec work toward the **Ship MVP** goal ("app live on the DO URL, /health green, chat round-trip via a seeded user").

## What changed (code/infra — the parts I can do)
**Terraform**
- `modules/app-platform/main.tf`: replaced the **sample-html placeholder** with the real spec — an `api` **service** (`backend/Dockerfile`, port 8080, health `/health`) + a `web` **static site** (React/Vite build, SPA catchall), fronted by **ingress** (`/api` → api with prefix stripped; `/` → web). Secrets as `type = "SECRET"`. **Removed `ignore_changes = [spec]`.**
- Added `magic_link_secret` + `resend_api_key` vars (the app *requires* both) + `TF_VAR_*` in both workflow jobs.
- `modules/database/ca.tf`: expose the cluster **CA certs** (`digitalocean_database_ca`) and pass them to the app so it can **verify** managed-DB TLS (verification stays on — no MITM hole).

**Backend**
- `core/database.py`: normalize Postgres URLs to **asyncpg** + strip libpq-only params (`sslmode`, …); attach SSL via `connect_args`, verifying against the DO cluster CA. `ca_pem()` accepts raw-PEM or base64.
- `core/valkey.py`: accept **`rediss://`** (DO Valkey) as TLS; optional `VALKEY_SSL_CA`.
- `config`: `DATABASE_SSL_CA` / `VALKEY_SSL_CA`.
- `scripts/seed_test_user.py`: age-verified user + JWT for post-deploy smoke (bypasses email).
- `tests/test_db_url.py`: URL-normalization tests.

**Verified:** `terraform validate` on **1.6.0** ✅; **36** backend tests pass ✅; `fmt` clean.

## ⚠️ Required from you before this deploys (I can't do these)
- [ ] **#26 Terraform Cloud:** repo Variable `TF_CLOUD_ORGANIZATION`; secret `TF_API_TOKEN`; create TFC workspaces `production` + `dev`.
- [ ] **GitHub Actions secrets:** `DO_TOKEN`, `JWT_SECRET_KEY`, `MAGIC_LINK_SECRET`, `RESEND_API_KEY` (placeholder ok for this milestone), `OPENROUTER_API_KEY` (**rotate the key shared in chat first**), `ENCRYPTION_KEY`, `ALERT_EMAIL`.
- [ ] **DO ↔ GitHub OAuth:** connect DigitalOcean to `epiphanyapps/chatbotAI` (App Platform builds from source).
- [ ] **#25:** required reviewers on the GitHub `production` Environment.

## Verify after deploy (dev first)
1. `curl https://<live-url>/health` → `{"status":"ok"}`.
2. `python -m scripts.seed_test_user` (from inside the VPC / admin IP) → JWT.
3. `POST /api/chat/message` with the JWT → Cydonia bubbles; open the web URL and chat via chrome-devtools MCP.

## Notes / to verify on first dev deploy
- The `api` service `source_dir = "backend"` + `dockerfile_path = "backend/Dockerfile"` combo may need a tweak depending on how App Platform sets the Docker build context — confirm on the first dev build.
- No Alembic: `create_tables()` on startup covers a **fresh** DB (fine here). Needed before Phase 4 touches an existing DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)